### PR TITLE
Scala xml support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,11 +7,7 @@ resolvers := allResolvers
 lazy val commonSettings = Seq(
   organization := "org.im.vdom",
   version := "0.1.0",
-  scalaVersion := "2.11.7",
-  EclipseKeys.useProjectId := true,
-  EclipseKeys.withSource := true,
-  EclipseKeys.skipParents in ThisBuild := false,
-  EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource
+  scalaVersion := "2.11.7"
 )
 
 lazy val commonScalacOptions = Seq("-Xlint", "-deprecation", "-Xfatal-warnings", "-feature")
@@ -28,7 +24,6 @@ lazy val root = (project in file(".")).
 lazy val vdom = crossProject.in(file(".")).
 	settings(scalacOptions ++= commonScalacOptions).
   settings(commonSettings: _*).
-  settings(EclipseKeys.useProjectId := true).
   settings(libraryDependencies ++= Seq("org.scalatest" %%% "scalatest" % "3.0.0-M15" % "test")).
 
   jvmSettings(libraryDependencies ++= Seq("org.scalacheck" %% "scalacheck" % "1.12.5" % "test")).

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,10 @@ lazy val vdom = crossProject.in(file(".")).
   settings(commonSettings: _*).
   settings(libraryDependencies ++= Seq("org.scalatest" %%% "scalatest" % "3.0.0-M15" % "test")).
 
-  jvmSettings(libraryDependencies ++= Seq("org.scalacheck" %% "scalacheck" % "1.12.5" % "test")).
+  jvmSettings(libraryDependencies ++= Seq(
+    "org.scala-lang.modules" %% "scala-xml" % "1.0.5" % "compile",
+    "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
+  )).
 
   jsSettings(
     relativeSourceMaps := true,

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ resolvers := allResolvers
 
 lazy val commonSettings = Seq(
   organization := "org.im.vdom",
-  version := "0.1.0",
+  version := "0.1.1-SNAPSHOT",
   scalaVersion := "2.11.7"
 )
 

--- a/jvm/src/main/scala/im/vdom/ScalaXml.scala
+++ b/jvm/src/main/scala/im/vdom/ScalaXml.scala
@@ -1,7 +1,17 @@
 package im.vdom
 
-import scala.xml.Node
+import scala.xml.{Text, UnprefixedAttribute, Node}
 
 object ScalaXml {
-  def nodeToVNode(xml:Node):VNode = VNode.empty
+  def nodeToVNode(xml:Node):VNode = {
+    val attrs = xml.attributes.collect { case UnprefixedAttribute(k, Text(v), _) =>
+      KeyValue(AttrKey(k), Some(v))
+    }.toSeq
+    val children = xml.nonEmptyChildren
+      .filter(n => n.label != "#PCDATA" || !n.text.trim.isEmpty)
+      .map(nodeToVNode)
+
+    if(xml.label == "#PCDATA") VNode.text(xml.text)
+    else VNode.tag(xml.label, attrs, children:_*)
+  }
 }

--- a/jvm/src/main/scala/im/vdom/ScalaXml.scala
+++ b/jvm/src/main/scala/im/vdom/ScalaXml.scala
@@ -1,0 +1,7 @@
+package im.vdom
+
+import scala.xml.Node
+
+object ScalaXml {
+  def nodeToVNode(xml:Node):VNode = VNode.empty
+}

--- a/jvm/src/test/scala/im/vdom/ScalaXmlSpec.scala
+++ b/jvm/src/test/scala/im/vdom/ScalaXmlSpec.scala
@@ -1,0 +1,15 @@
+package im.vdom
+
+import org.scalatest.WordSpec
+import ScalaXml._
+
+import scala.xml.Node
+
+class ScalaXmlSpec extends WordSpec {
+  "ScalaXml.nodeSeqToVNode()" should {
+    "convert an empty NodeSeq into VNode.empty" in {
+      assertResult(VNode.empty)(nodeToVNode(<empty/>))
+    }
+  }
+
+}

--- a/jvm/src/test/scala/im/vdom/ScalaXmlSpec.scala
+++ b/jvm/src/test/scala/im/vdom/ScalaXmlSpec.scala
@@ -22,7 +22,7 @@ class ScalaXmlSpec extends WordSpec {
 
     "convert a Node with text" in {
       val html = <span>This is text</span>
-      val expected = tag("span", Seq(), text("This is text"))
+      val expected = tag("span", text("This is text"))
 
       assertResult(expected)(nodeToVNode(html))
     }
@@ -38,7 +38,7 @@ class ScalaXmlSpec extends WordSpec {
 
       val expected =
         tag("form", Seq(KeyValue(AttrKey("method"), Some("post"))),
-          tag("div", Seq(),
+          tag("div",
             tag("input", Seq(KeyValue(AttrKey("type"), Some("text")), KeyValue(AttrKey("id"), Some("chat-in")), KeyValue(AttrKey("name"), Some("in")))),
             tag("input", Seq(KeyValue(AttrKey("type"), Some("submit")), KeyValue(AttrKey("value"), Some("Submit"))))
           )

--- a/jvm/src/test/scala/im/vdom/ScalaXmlSpec.scala
+++ b/jvm/src/test/scala/im/vdom/ScalaXmlSpec.scala
@@ -2,13 +2,49 @@ package im.vdom
 
 import org.scalatest.WordSpec
 import ScalaXml._
-
-import scala.xml.Node
+import VNode._
 
 class ScalaXmlSpec extends WordSpec {
-  "ScalaXml.nodeSeqToVNode()" should {
-    "convert an empty NodeSeq into VNode.empty" in {
-      assertResult(VNode.empty)(nodeToVNode(<empty/>))
+  "ScalaXml.nodeToVNode()" should {
+    "convert a trivial empty Node into a VNode.tag" in {
+      val html = <br/>
+      val expected = tag("br")
+
+      assertResult(expected)(nodeToVNode(html))
+    }
+
+    "convert an empty Node with attributes" in {
+      val html = <div id="my-id" class="my-class"></div>
+      val expected = tag("div", Seq(KeyValue(AttrKey("id"), Some("my-id")), KeyValue(AttrKey("class"), Some("my-class"))))
+
+      assertResult(expected)(nodeToVNode(html))
+    }
+
+    "convert a Node with text" in {
+      val html = <span>This is text</span>
+      val expected = tag("span", Seq(), text("This is text"))
+
+      assertResult(expected)(nodeToVNode(html))
+    }
+
+    "convert a Node with children and attributes" in {
+      val html =
+        <form method="post">
+          <div>
+            <input type="text" id="chat-in" name="in"/>
+            <input type="submit" value="Submit"/>
+          </div>
+        </form>
+
+      val expected =
+        tag("form", Seq(KeyValue(AttrKey("method"), Some("post"))),
+          tag("div", Seq(),
+            tag("input", Seq(KeyValue(AttrKey("type"), Some("text")), KeyValue(AttrKey("id"), Some("chat-in")), KeyValue(AttrKey("name"), Some("in")))),
+            tag("input", Seq(KeyValue(AttrKey("type"), Some("submit")), KeyValue(AttrKey("value"), Some("Submit"))))
+          )
+        )
+
+      assertResult(expected)(nodeToVNode(html))
     }
   }
 


### PR DESCRIPTION
I implemented code to convert a `scala.xml.Node` to `VNode` in the jvm project.  

In order to work with your project, I had to rip out the `EclipseKey` references in your build file. I suspect you may have an eclipse plugin installed globally on your system that isn't present here.
